### PR TITLE
Removed normalization on the final output

### DIFF
--- a/deep_daze/deep_daze.py
+++ b/deep_daze/deep_daze.py
@@ -223,7 +223,7 @@ class Imagine(nn.Module):
 
         if i % self.save_every == 0:
             with torch.no_grad():
-                img = normalize_image(self.model(self.encoded_text, return_loss = False).cpu())
+                img = self.model(self.encoded_text, return_loss = False).cpu()
                 img.clamp_(0., 1.)
                 save_image(img, str(self.filename))
                 print(f'image updated at "./{str(self.filename)}"')


### PR DESCRIPTION
Because the model is already normalized during the slice-batch-processing, there's no need to normalize it again.